### PR TITLE
fix(config): 更新 vitepress-plugin-permalink 版本并修复浏览器导航问题

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -11,7 +11,7 @@
     "vitepress-plugin-doc-analysis": "catalog:",
     "vitepress-plugin-file-content-loader": "catalog:",
     "vitepress-plugin-md-h1": "catalog:",
-    "vitepress-plugin-permalink": "workspace:*",
+    "vitepress-plugin-permalink": "catalog:",
     "vitepress-plugin-sidebar-resolve": "catalog:"
   },
   "devDependencies": {

--- a/packages/teek/package-release.json
+++ b/packages/teek/package-release.json
@@ -70,7 +70,7 @@
     "vitepress-plugin-doc-analysis": "^1.0.12",
     "vitepress-plugin-file-content-loader": "^1.0.12",
     "vitepress-plugin-md-h1": "^1.0.11",
-    "vitepress-plugin-permalink": "^1.1.5",
+    "vitepress-plugin-permalink": "^1.1.6",
     "vitepress-plugin-sidebar-resolve": "^1.1.2"
   },
   "devDependencies": {

--- a/plugins/vitepress-plugin-permalink/CHANGELOG.md
+++ b/plugins/vitepress-plugin-permalink/CHANGELOG.md
@@ -1,5 +1,11 @@
 # vitepress-plugin-permalink
 
+## 1.1.6
+
+### Patch Changes
+
+- 修复浏览器前进后退仍然出现 404 页面问题
+
 ## 1.1.5
 
 ### Patch Changes

--- a/plugins/vitepress-plugin-permalink/package.json
+++ b/plugins/vitepress-plugin-permalink/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vitepress-plugin-permalink",
   "type": "module",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "扫描 Markdown 文档，生成永久链接",
   "author": {
     "name": "teeker",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ catalogs:
     vitepress-plugin-md-h1:
       specifier: ^1.0.11
       version: 1.0.11
+    vitepress-plugin-permalink:
+      specifier: ^1.1.6
+      version: 1.1.6
     vitepress-plugin-sidebar-resolve:
       specifier: ^1.1.2
       version: 1.1.2
@@ -327,8 +330,8 @@ importers:
         specifier: 'catalog:'
         version: 1.0.11
       vitepress-plugin-permalink:
-        specifier: workspace:*
-        version: link:../../plugins/vitepress-plugin-permalink
+        specifier: 'catalog:'
+        version: 1.1.6(vitepress@1.6.3(@algolia/client-search@5.19.0)(@types/node@22.14.0)(async-validator@4.2.5)(postcss@8.5.3)(sass@1.83.1)(search-insights@2.17.3)(typescript@5.8.3))
       vitepress-plugin-sidebar-resolve:
         specifier: 'catalog:'
         version: 1.1.2(vitepress@1.6.3(@algolia/client-search@5.19.0)(@types/node@22.14.0)(async-validator@4.2.5)(postcss@8.5.3)(sass@1.83.1)(search-insights@2.17.3)(typescript@5.8.3))
@@ -5037,6 +5040,11 @@ packages:
 
   vitepress-plugin-md-h1@1.0.11:
     resolution: {integrity: sha512-oZhS8NwsMk+chZBul4RzvbEUdDEVxJXorgLHf2S2U/eAyq8XENXFLhpGa3MKV0rVVA4WiN5K5eBv4ZOCmzxI7A==}
+
+  vitepress-plugin-permalink@1.1.6:
+    resolution: {integrity: sha512-SyBbbeK5ofnQSpnvYx4jHEtWinj3kCsntdASWmPy4y4dUKnyjRk0OT9ZaeMxxsO8aVhvXfuMydZAnDsZuEiDnw==}
+    peerDependencies:
+      vitepress: ^1.6.3
 
   vitepress-plugin-sidebar-resolve@1.1.2:
     resolution: {integrity: sha512-73Xl2hRFfAR+kf2GGMuYC96uN5VXsiFJjTezGD8CyC5kZzaU3hVxr+FkGbxk3CPynDaDNyyRJEu/LYYvD9dv9Q==}
@@ -10007,6 +10015,12 @@ snapshots:
   vitepress-plugin-md-h1@1.0.11:
     dependencies:
       gray-matter: 4.0.3
+
+  vitepress-plugin-permalink@1.1.6(vitepress@1.6.3(@algolia/client-search@5.19.0)(@types/node@22.14.0)(async-validator@4.2.5)(postcss@8.5.3)(sass@1.83.1)(search-insights@2.17.3)(typescript@5.8.3)):
+    dependencies:
+      gray-matter: 4.0.3
+      picocolors: 1.1.1
+      vitepress: 1.6.3(@algolia/client-search@5.19.0)(@types/node@22.14.0)(async-validator@4.2.5)(postcss@8.5.3)(sass@1.83.1)(search-insights@2.17.3)(typescript@5.8.3)
 
   vitepress-plugin-sidebar-resolve@1.1.2(vitepress@1.6.3(@algolia/client-search@5.19.0)(@types/node@22.14.0)(async-validator@4.2.5)(postcss@8.5.3)(sass@1.83.1)(search-insights@2.17.3)(typescript@5.8.3)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,7 +23,7 @@ catalog:
   vitepress-plugin-doc-analysis: ^1.0.12
   vitepress-plugin-file-content-loader: ^1.0.12
   vitepress-plugin-md-h1: ^1.0.11
-  vitepress-plugin-permalink: ^1.1.5
+  vitepress-plugin-permalink: ^1.1.6
   vitepress-plugin-sidebar-resolve: ^1.1.2
 
 catalogs:


### PR DESCRIPTION
- 将 vitepress-plugin-permalink 版本从 1.1.5 升级到 1.1.6
- 修复了浏览器前进后退时出现 404 页面的问题
- 更新了相关配置文件和依赖版本